### PR TITLE
Update the ports to be 3010 and 8010 everywhere and remove unused old depencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,3 +114,4 @@ The built-in browser tool fails on NixOS due to incompatible Chromium binaries. 
 - Not all router modules are mounted in `main.py` (tastings, whiskeys, users routers exist but not included)
 - Test seed data references unimplemented endpoints (e.g., PUT `/themes/{theme_id}/whiskeys`)
 - Backend includes Windows-specific asyncio fix for Playwright compatibility
+- When modifying Python dependencies in `apps/backend/pyproject.toml` or `apps/backend/requirements.txt`, also update `nix/pythonShell.nix` to maintain consistency across environments

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -6,21 +6,15 @@ requires-python = ">=3.13"
 dependencies = [
     "fastapi>=0.115.0",
     "uvicorn>=0.34.0",
-    "python-multipart>=0.0.20",
     "pydantic>=2.11.0",
     "pydantic-settings>=2.8.0",
     "tinydb>=4.8.0",
-    "litellm>=1.56.0",
-    "markitdown>=0.1.0",
-    "pdfminer.six>=20231228",
-    "playwright>=1.50.0",
-    "python-docx>=1.1.0",
-    "python-dotenv>=1.1.0",
 ]
 
 [project.optional-dependencies]
 dev = [
     "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0",
     "pytest-cov>=4.0.0",
     "httpx>=0.28.0",
 ]

--- a/apps/backend/requirements.txt
+++ b/apps/backend/requirements.txt
@@ -1,10 +1,5 @@
 fastapi>=0.115.0
 uvicorn>=0.34.0
-python-multipart>=0.0.20
 pydantic>=2.11.0
 pydantic-settings>=2.8.0
 tinydb>=4.8.0
-litellm>=1.56.0
-markitdown>=0.1.0
-playwright>=1.50.0
-python-dotenv>=1.1.0

--- a/apps/frontend/lib/api/client.ts
+++ b/apps/frontend/lib/api/client.ts
@@ -4,7 +4,7 @@
  * Single source of truth for API configuration and base fetch utilities.
  */
 
-export const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+export const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8010';
 export const API_BASE = `${API_URL}/api/v1`;
 
 /**

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "next dev --turbopack -p 3010",
     "build": "next build",
     "start": "next start",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx .",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,14 +6,14 @@ services:
     image: whiskey-tasting
     container_name: whiskey-tasting
     ports:
-      - "3010:3000"   # Frontend
-      - "8010:8000"   # Backend API
+      - "3010:3010"   # Frontend
+      - "8010:8010"   # Backend API
     volumes:
       - whiskey-data:/app/backend/data
     environment:
       - NODE_ENV=production
-      - NEXT_PUBLIC_API_URL=http://localhost:8000
-      - PORT=3000
+      - NEXT_PUBLIC_API_URL=http://localhost:8010
+      - PORT=3010
       - HOSTNAME=0.0.0.0
     restart: unless-stopped
     healthcheck:

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -95,13 +95,13 @@ status "Data directory setup complete"
 echo ""
 info "Starting backend server..."
 cd /app/backend
-python -m uvicorn app.main:app --host 0.0.0.0 --port 8000 &
+python -m uvicorn app.main:app --host 0.0.0.0 --port 8010 &
 BACKEND_PID=$!
 
 # Wait for backend to be ready
 info "Waiting for backend to be ready..."
 for i in {1..30}; do
-    if curl -s http://localhost:8000/api/v1/health > /dev/null 2>&1; then
+    if curl -s http://localhost:8010/api/v1/health > /dev/null 2>&1; then
         status "Backend is ready (PID: $BACKEND_PID)"
         break
     fi
@@ -124,9 +124,9 @@ echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━�
 echo ""
 status "Whiskey Tasting is running!"
 echo ""
-echo -e "  ${BOLD}Frontend:${NC}  http://localhost:3000"
-echo -e "  ${BOLD}Backend:${NC}   http://localhost:8000"
-echo -e "  ${BOLD}API Docs:${NC}  http://localhost:8000/docs"
+echo -e "  ${BOLD}Frontend:${NC}  http://localhost:3010"
+echo -e "  ${BOLD}Backend:${NC}   http://localhost:8010"
+echo -e "  ${BOLD}API Docs:${NC}  http://localhost:8010/docs"
 echo ""
 echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 echo ""

--- a/nix/pythonShell.nix
+++ b/nix/pythonShell.nix
@@ -4,16 +4,9 @@ pkgs.mkShell {
     (python3.withPackages (ps: [
       ps.fastapi
       ps.uvicorn
-      ps.python-multipart
       ps.pydantic
       ps.pydantic-settings
       ps.tinydb
-      ps.litellm
-      ps.markitdown
-      ps.pdfminer-six
-      ps.playwright
-      ps.python-docx
-      ps.python-dotenv
       ps.pytest
       ps.pytest-asyncio
       ps.pytest-cov


### PR DESCRIPTION
All mentioned ports should now be 3010 and 8010 and all the python dependencies that were leftover from the migration should be removed now. Oh and the AGENTS.ms should be updated to only include what is needed. There are still things left for testing with playwright in windows. I have not tested in NixOs yes. That is another task.