### PR TITLE
Fix release job: use built-in GITHUB_TOKEN instead of GH_TOKEN PAT

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   assign-reviewers:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -15,4 +17,4 @@ jobs:
         if: github.event.pull_request.user.login != 'Reasel'
         run: gh pr edit ${{ github.event.pull_request.number }} --add-reviewer Reasel
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -90,6 +90,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment: production
+    permissions:
+      contents: write
 
     steps:
     - name: Checkout code
@@ -130,4 +132,4 @@ jobs:
         draft: false
         prerelease: false
       env:
-        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- The `v*` production release job failed with `Resource not accessible by integration` because the token creating the GitHub Release lacked `contents: write` (it ran with the default read-only Actions permissions).
- Switch both the **Create GitHub Release** step (`ci-cd.yml`) and the **auto-assign-reviewer** job (`auto-assign.yml`) from the `GH_TOKEN` PAT to the built-in `GITHUB_TOKEN`, adding explicit per-job `permissions` (`contents: write` and `pull-requests: write` respectively).
- The `GH_TOKEN` repo secret is now unused by any workflow and can be deleted.

## Test plan
- [ ] After merge, push a new `v*` tag (e.g. `v0.2.1`) and confirm the `Create GitHub Release` step succeeds and the release is published.
- [ ] Confirm the Docker image still builds/pushes (unchanged path).
- [ ] Open a PR authored by a non-`Reasel` user and confirm auto-assign still adds the reviewer with the built-in token.