### PR TITLE
fix: mobile UI polish — rating pip fill, GlowBox borders, podium, notes links, Home button

### DIFF
--- a/apps/mobile/app/admin/index.tsx
+++ b/apps/mobile/app/admin/index.tsx
@@ -17,6 +17,8 @@ export default function AdminIndexScreen() {
         <ScreenHeader
           title="ADMINISTRATION"
           eyebrow="MANAGE THEMES, USERS, AND SETTINGS"
+          backLabel="HOME"
+          onBack={() => router.push('/')}
         />
 
         <View style={styles.grid}>

--- a/apps/mobile/app/admin/themes.tsx
+++ b/apps/mobile/app/admin/themes.tsx
@@ -15,6 +15,7 @@ import { Input } from '../../components/ui/Input';
 import { Card } from '../../components/ui/Card';
 import { Toast } from '../../components/ui/Toast';
 import { AppText } from '../../components/ui/AppText';
+import { RichNotes } from '../../components/ui/RichNotes';
 import { ScreenHeader } from '../../components/ui/ScreenHeader';
 import { Stepper } from '../../components/ui/Stepper';
 import {
@@ -260,7 +261,12 @@ export default function ThemesScreen() {
                 <View style={styles.themeInfo}>
                   <AppText variant="sectionTitle">{theme.name}</AppText>
                   {theme.notes ? (
-                    <AppText variant="body" style={styles.themeNotes}>{theme.notes}</AppText>
+                    <RichNotes
+                      text={theme.notes}
+                      variant="body"
+                      style={{ marginTop: 2 }}
+                      textStyle={{ color: colors.dim }}
+                    />
                   ) : null}
                 </View>
                 <Button

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -87,20 +87,22 @@ export default function HomeScreen() {
           </View>
         ) : tonight ? (
           <View style={styles.tonightStrip}>
-            <View style={styles.tonightLeft}>
-              <PulsingDot size={8} color={colors.amber} />
-              <AppText style={styles.tonightLabel}>TONIGHT</AppText>
+            <View style={styles.tonightMeta}>
+              <View style={styles.tonightLeft}>
+                <PulsingDot size={8} color={colors.amber} />
+                <AppText style={styles.tonightLabel}>TONIGHT</AppText>
+              </View>
+              <View style={styles.tonightStats}>
+                <AppText style={styles.tonightStat}>
+                  <AppText style={styles.tonightStatBold}>{tonight.pours}</AppText> POURS
+                </AppText>
+                <View style={styles.sep} />
+                <AppText style={styles.tonightStat}>
+                  <AppText style={styles.tonightStatBold}>{tonight.tasters}</AppText> IN
+                </AppText>
+              </View>
             </View>
-            <AppText style={styles.tonightName} numberOfLines={1}>{tonight.theme.name}</AppText>
-            <View style={styles.tonightStats}>
-              <AppText style={styles.tonightStat}>
-                <AppText style={styles.tonightStatBold}>{tonight.pours}</AppText> POURS
-              </AppText>
-              <View style={styles.sep} />
-              <AppText style={styles.tonightStat}>
-                <AppText style={styles.tonightStatBold}>{tonight.tasters}</AppText> IN
-              </AppText>
-            </View>
+            <AppText style={styles.tonightName}>{tonight.theme.name}</AppText>
           </View>
         ) : (
           <View style={styles.tonightStrip}>
@@ -142,16 +144,18 @@ const styles = StyleSheet.create({
   },
 
   tonightStrip: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing.md,
-    flexWrap: 'wrap',
     backgroundColor: 'rgba(0,0,0,0.3)',
     borderWidth: 1,
     borderColor: colors.line,
     paddingHorizontal: spacing.lg,
     paddingVertical: spacing.md,
     marginBottom: spacing.xl,
+  },
+  tonightMeta: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: spacing.xs,
   },
   tonightLeft: { flexDirection: 'row', alignItems: 'center', gap: spacing.sm },
   tonightLabel: {
@@ -164,9 +168,8 @@ const styles = StyleSheet.create({
     fontFamily: fonts.serifSemi,
     fontSize: 20,
     color: colors.cream,
-    flex: 1,
   },
-  tonightStats: { flexDirection: 'row', alignItems: 'center', gap: spacing.sm, marginLeft: 'auto' },
+  tonightStats: { flexDirection: 'row', alignItems: 'center', gap: spacing.sm },
   tonightStat: { fontFamily: fonts.monoRegular, fontSize: 12, letterSpacing: 1.4, color: colors.dim },
   tonightStatBold: { fontFamily: fonts.monoBold, color: colors.amber },
   sep: { width: 1, height: 14, backgroundColor: colors.line },

--- a/apps/mobile/components/dashboard/ByThemeView.tsx
+++ b/apps/mobile/components/dashboard/ByThemeView.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { View, StyleSheet } from 'react-native';
 import { colors, spacing, fonts } from '../../lib/theme';
 import { AppText } from '../ui/AppText';
+import { RichNotes } from '../ui/RichNotes';
 import { Card } from '../ui/Card';
 import { Accordion } from '../ui/Accordion';
 import { whiskeyBreakdown } from '../../lib/scoring';
@@ -29,9 +30,7 @@ export function ByThemeView({ allScores }: Props) {
           style={styles.themeCard}
         >
           {t.theme.notes ? (
-            <AppText variant="bodyMuted" style={styles.notes}>
-              {t.theme.notes}
-            </AppText>
+            <RichNotes text={t.theme.notes} variant="bodyMuted" style={styles.notes} />
           ) : null}
           {t.whiskeys.map((w) => (
             <WhiskeyAccordion key={w.whiskey_id} whiskey={w} />

--- a/apps/mobile/components/dashboard/ResultsReveal.tsx
+++ b/apps/mobile/components/dashboard/ResultsReveal.tsx
@@ -16,7 +16,7 @@ import { leaderboard, consensus } from '../../lib/scoring';
 import type { ThemeScoresResponse } from '../../lib/api';
 
 // Podium fill percentages by medal place (handoff spec).
-const PODIUM_FILL: Record<1 | 2 | 3, number> = { 1: 64, 2: 82, 3: 50 };
+const PODIUM_FILL: Record<1 | 2 | 3, number> = { 1: 82, 2: 64, 3: 50 };
 
 interface Props {
   // revealKey changes on each refresh to retrigger the cascade.

--- a/apps/mobile/components/dashboard/ResultsReveal.tsx
+++ b/apps/mobile/components/dashboard/ResultsReveal.tsx
@@ -9,7 +9,6 @@ import {
 import { colors, spacing, fonts } from '../../lib/theme';
 import { AppText } from '../ui/AppText';
 import { Eyebrow } from '../ui/Eyebrow';
-import { GlowBox } from '../ui/GlowBox';
 import { PodiumGlass } from '../ui/PodiumGlass';
 import { RankedBar } from '../ui/RankedBar';
 import { leaderboard, consensus } from '../../lib/scoring';
@@ -215,7 +214,7 @@ function ConsensusRow({
     </View>
   );
 
-  return top ? <GlowBox intensity="soft">{row}</GlowBox> : row;
+  return row;
 }
 
 const styles = StyleSheet.create({

--- a/apps/mobile/components/dashboard/ResultsReveal.tsx
+++ b/apps/mobile/components/dashboard/ResultsReveal.tsx
@@ -262,7 +262,6 @@ const styles = StyleSheet.create({
     borderBottomColor: colors.line,
   },
   consRowTop: {
-    backgroundColor: colors.glowSoft,
     borderBottomColor: colors.amber,
   },
   consRank: { width: 28 },

--- a/apps/mobile/components/ui/PodiumGlass.tsx
+++ b/apps/mobile/components/ui/PodiumGlass.tsx
@@ -9,7 +9,6 @@ import Svg, {
   Stop,
 } from 'react-native-svg';
 import { colors } from '../../lib/theme';
-import { GlowBox } from './GlowBox';
 
 interface PodiumGlassProps {
   place: 1 | 2 | 3;
@@ -65,32 +64,30 @@ export function PodiumGlass({ place, fillPct, animate }: PodiumGlassProps) {
   const path = `M${TOP_INSET} 0 L${GLASS_WIDTH - TOP_INSET} 0 L${GLASS_WIDTH - TOP_INSET * 2} ${h} L${TOP_INSET * 2} ${h} Z`;
 
   return (
-    <GlowBox intensity={place === 1 ? 'strong' : 'soft'} color={colors.glow}>
-      <View style={styles.wrap}>
-        <Svg width={GLASS_WIDTH} height={h}>
-          <Defs>
-            <ClipPath id={`glass-${place}`}>
-              <Path d={path} />
-            </ClipPath>
-            <LinearGradient id={`fill-${place}`} x1="0" y1="0" x2="0" y2="1">
-              <Stop offset="0" stopColor={colors.amberSoft} />
-              <Stop offset="1" stopColor={colors.ember} />
-            </LinearGradient>
-          </Defs>
-          {/* Glass body */}
-          <Path d={path} fill={colors.panel} stroke={colors.line} strokeWidth={1} />
-          {/* Animated amber fill, masked to the glass shape */}
-          <AnimatedRect
-            x={0}
-            y={fillY}
-            width={GLASS_WIDTH}
-            height={fillHeight}
-            fill={`url(#fill-${place})`}
-            clipPath={`url(#glass-${place})`}
-          />
-        </Svg>
-      </View>
-    </GlowBox>
+    <View style={styles.wrap}>
+      <Svg width={GLASS_WIDTH} height={h}>
+        <Defs>
+          <ClipPath id={`glass-${place}`}>
+            <Path d={path} />
+          </ClipPath>
+          <LinearGradient id={`fill-${place}`} x1="0" y1="0" x2="0" y2="1">
+            <Stop offset="0" stopColor={colors.amberSoft} />
+            <Stop offset="1" stopColor={colors.ember} />
+          </LinearGradient>
+        </Defs>
+        {/* Glass body */}
+        <Path d={path} fill={colors.panel} stroke={colors.line} strokeWidth={1} />
+        {/* Animated amber fill, masked to the glass shape */}
+        <AnimatedRect
+          x={0}
+          y={fillY}
+          width={GLASS_WIDTH}
+          height={fillHeight}
+          fill={`url(#fill-${place})`}
+          clipPath={`url(#glass-${place})`}
+        />
+      </Svg>
+    </View>
   );
 }
 

--- a/apps/mobile/components/ui/RankPills.tsx
+++ b/apps/mobile/components/ui/RankPills.tsx
@@ -3,7 +3,6 @@ import { View, Pressable, StyleSheet } from 'react-native';
 import * as Haptics from 'expo-haptics';
 import { colors, spacing, fonts } from '../../lib/theme';
 import { AppText } from './AppText';
-import { GlowBox } from './GlowBox';
 
 interface RankPillsProps {
   value: number;
@@ -33,11 +32,7 @@ export function RankPills({ value, count, onChange }: RankPillsProps) {
             </AppText>
           </Pressable>
         );
-        return active ? (
-          <GlowBox key={n} intensity="soft" style={styles.cell}>
-            {pill}
-          </GlowBox>
-        ) : (
+        return (
           <View key={n} style={styles.cell}>
             {pill}
           </View>

--- a/apps/mobile/components/ui/RichNotes.tsx
+++ b/apps/mobile/components/ui/RichNotes.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { Text, Image, View, Pressable, Linking, StyleSheet } from 'react-native';
+import { colors, typography, spacing } from '../../lib/theme';
+import type { TypoVariant } from '../../lib/theme';
+import type { TextStyle, ViewStyle } from 'react-native';
+
+const URL_RE = /(https?:\/\/[^\s<>"']+)/g;
+const IMAGE_EXT_RE = /\.(jpe?g|png|gif|webp)(\?[^\s]*)?$/i;
+
+type Seg =
+  | { kind: 'text'; text: string }
+  | { kind: 'link'; url: string }
+  | { kind: 'image'; url: string };
+
+function parse(raw: string): Seg[] {
+  const segs: Seg[] = [];
+  let last = 0;
+  let m: RegExpExecArray | null;
+  URL_RE.lastIndex = 0;
+  while ((m = URL_RE.exec(raw)) !== null) {
+    if (m.index > last) segs.push({ kind: 'text', text: raw.slice(last, m.index) });
+    const url = m[1];
+    segs.push(IMAGE_EXT_RE.test(url.split('?')[0]) ? { kind: 'image', url } : { kind: 'link', url });
+    last = m.index + m[0].length;
+  }
+  if (last < raw.length) segs.push({ kind: 'text', text: raw.slice(last) });
+  return segs;
+}
+
+interface RichNotesProps {
+  text: string;
+  variant?: TypoVariant;
+  /** Applied to the outer container View (margins, padding). */
+  style?: ViewStyle;
+  /** Applied to inline text spans (color overrides). */
+  textStyle?: TextStyle;
+}
+
+/** Renders theme notes with clickable links and inline images.
+ *  Image URLs (.jpg/.png/.gif/.webp) display as a tappable inline image.
+ *  Other URLs display as amber underlined text that opens in the browser. */
+export function RichNotes({ text, variant = 'body', style, textStyle }: RichNotesProps) {
+  const segs = parse(text);
+
+  // Group consecutive text/link segs into inline runs; images break out as blocks.
+  const blocks: Array<{ type: 'inline'; segs: Seg[] } | { type: 'image'; url: string }> = [];
+  let run: Seg[] = [];
+  for (const seg of segs) {
+    if (seg.kind === 'image') {
+      if (run.length) {
+        blocks.push({ type: 'inline', segs: run });
+        run = [];
+      }
+      blocks.push({ type: 'image', url: seg.url });
+    } else {
+      run.push(seg);
+    }
+  }
+  if (run.length) blocks.push({ type: 'inline', segs: run });
+
+  return (
+    <View style={style}>
+      {blocks.map((block, i) => {
+        if (block.type === 'image') {
+          return (
+            <Pressable key={i} onPress={() => Linking.openURL(block.url).catch(() => {})}>
+              <Image source={{ uri: block.url }} style={styles.img} resizeMode="contain" />
+            </Pressable>
+          );
+        }
+        return (
+          <Text key={i} style={[typography[variant], textStyle]}>
+            {block.segs.map((seg, j) =>
+              seg.kind === 'link' ? (
+                <Text
+                  key={j}
+                  style={styles.link}
+                  onPress={() => Linking.openURL(seg.url).catch(() => {})}
+                >
+                  {seg.url}
+                </Text>
+              ) : seg.kind === 'text' ? (
+                seg.text
+              ) : null
+            )}
+          </Text>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  link: {
+    color: colors.amber,
+    textDecorationLine: 'underline',
+  },
+  img: {
+    width: '100%',
+    height: 200,
+    marginVertical: spacing.sm,
+    backgroundColor: colors.raise,
+  },
+});

--- a/apps/mobile/components/ui/TactileRating.tsx
+++ b/apps/mobile/components/ui/TactileRating.tsx
@@ -121,7 +121,7 @@ export function TactileRating({ value, onChange, max = 5 }: TactileRatingProps) 
                 {frac > 0 && (
                   <View
                     pointerEvents="none"
-                    style={[styles.pipFill, { transform: [{ scaleY: frac }] }]}
+                    style={[styles.pipFill, { height: frac * PIP_H }]}
                   />
                 )}
                 <AppText style={[styles.pipNum, isActive && styles.pipNumActive]}>
@@ -182,9 +182,7 @@ const styles = StyleSheet.create({
     left: 0,
     right: 0,
     bottom: 0,
-    height: '100%',
     backgroundColor: colors.amber,
-    transformOrigin: 'bottom',
   },
   pipNum: {
     fontFamily: fonts.monoMedium,


### PR DESCRIPTION
## Summary

- **Rating pip fill**: use direct height instead of `scaleY` transform so pips fill correctly on Android
- **GlowBox / podium**: remove border artefacts on Android from GlowBox; fix podium fill order
- **Consensus row**: remove background shading and GlowBox border from top consensus row
- **Theme notes**: render URLs as clickable links and inline images
- **Tonight strip**: show full theme name without truncation
- **Admin**: add Home button to administration index screen

## Test Plan
- [ ] Rating pips fill from bottom up on Android emulator
- [ ] Podium glasses render in correct fill order with no border artefacts
- [ ] Top consensus row has no background shading or border
- [ ] Theme notes with URLs render as tappable links / inline images
- [ ] Tonight strip shows full theme name
- [ ] Administration index screen has a working Home button