### PR TITLE
ci: ntfy notifications before deploy approvals

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -124,8 +124,41 @@ jobs:
     steps:
     - run: echo "All tests passed"
 
-  build-and-deploy-staging:
+  notify-staging-deploy:
     needs: [test]
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Notify staging deploy pending
+      env:
+        NTFY_URL: ${{ secrets.NTFY_URL }}
+        NTFY_TOPIC: ${{ secrets.NTFY_TOPIC }}
+        NTFY_TOKEN: ${{ secrets.NTFY_TOKEN }}
+        NTFY_AUTH_USER: ${{ secrets.NTFY_AUTH_USER }}
+        NTFY_AUTH_PASS: ${{ secrets.NTFY_AUTH_PASS }}
+      run: |
+        if [ -z "$NTFY_URL" ] || [ -z "$NTFY_TOPIC" ]; then
+          echo "NTFY not configured, skipping notification"
+          exit 0
+        fi
+        RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        AUTH_ARGS=()
+        if [ -n "$NTFY_TOKEN" ]; then
+          AUTH_ARGS+=(-H "Authorization: Bearer $NTFY_TOKEN")
+        elif [ -n "$NTFY_AUTH_USER" ] && [ -n "$NTFY_AUTH_PASS" ]; then
+          AUTH_ARGS+=(-u "$NTFY_AUTH_USER:$NTFY_AUTH_PASS")
+        fi
+        curl -sf \
+          "${AUTH_ARGS[@]}" \
+          -H "Title: Staging deploy needs approval" \
+          -H "Priority: high" \
+          -H "Tags: rocket" \
+          -H "Click: $RUN_URL" \
+          -d "Commit ${{ github.sha }} by ${{ github.actor }} is waiting for staging approval — tap to review." \
+          "$NTFY_URL/$NTFY_TOPIC" || true
+
+  build-and-deploy-staging:
+    needs: [test, notify-staging-deploy]
     if: github.ref == 'refs/heads/master' && github.event_name == 'push'
     runs-on: ubuntu-latest
     environment: staging
@@ -156,8 +189,41 @@ jobs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
 
-  build-and-deploy-production:
+  notify-production-deploy:
     needs: [test]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+    - name: Notify production deploy pending
+      env:
+        NTFY_URL: ${{ secrets.NTFY_URL }}
+        NTFY_TOPIC: ${{ secrets.NTFY_TOPIC }}
+        NTFY_TOKEN: ${{ secrets.NTFY_TOKEN }}
+        NTFY_AUTH_USER: ${{ secrets.NTFY_AUTH_USER }}
+        NTFY_AUTH_PASS: ${{ secrets.NTFY_AUTH_PASS }}
+      run: |
+        if [ -z "$NTFY_URL" ] || [ -z "$NTFY_TOPIC" ]; then
+          echo "NTFY not configured, skipping notification"
+          exit 0
+        fi
+        RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        AUTH_ARGS=()
+        if [ -n "$NTFY_TOKEN" ]; then
+          AUTH_ARGS+=(-H "Authorization: Bearer $NTFY_TOKEN")
+        elif [ -n "$NTFY_AUTH_USER" ] && [ -n "$NTFY_AUTH_PASS" ]; then
+          AUTH_ARGS+=(-u "$NTFY_AUTH_USER:$NTFY_AUTH_PASS")
+        fi
+        curl -sf \
+          "${AUTH_ARGS[@]}" \
+          -H "Title: Production deploy needs approval" \
+          -H "Priority: urgent" \
+          -H "Tags: rocket,warning" \
+          -H "Click: $RUN_URL" \
+          -d "Tag ${{ github.ref_name }} by ${{ github.actor }} is waiting for production approval — tap to review." \
+          "$NTFY_URL/$NTFY_TOPIC" || true
+
+  build-and-deploy-production:
+    needs: [test, notify-production-deploy]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment: production

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -33,7 +33,40 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  notify-mobile-deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Notify mobile deploy pending
+      env:
+        NTFY_URL: ${{ secrets.NTFY_URL }}
+        NTFY_TOPIC: ${{ secrets.NTFY_TOPIC }}
+        NTFY_TOKEN: ${{ secrets.NTFY_TOKEN }}
+        NTFY_AUTH_USER: ${{ secrets.NTFY_AUTH_USER }}
+        NTFY_AUTH_PASS: ${{ secrets.NTFY_AUTH_PASS }}
+      run: |
+        if [ -z "$NTFY_URL" ] || [ -z "$NTFY_TOPIC" ]; then
+          echo "NTFY not configured, skipping notification"
+          exit 0
+        fi
+        PROFILE="${{ inputs.profile || 'production' }}"
+        RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        AUTH_ARGS=()
+        if [ -n "$NTFY_TOKEN" ]; then
+          AUTH_ARGS+=(-H "Authorization: Bearer $NTFY_TOKEN")
+        elif [ -n "$NTFY_AUTH_USER" ] && [ -n "$NTFY_AUTH_PASS" ]; then
+          AUTH_ARGS+=(-u "$NTFY_AUTH_USER:$NTFY_AUTH_PASS")
+        fi
+        curl -sf \
+          "${AUTH_ARGS[@]}" \
+          -H "Title: Mobile deploy needs approval" \
+          -H "Priority: high" \
+          -H "Tags: iphone,rocket" \
+          -H "Click: $RUN_URL" \
+          -d "Mobile $PROFILE build (${{ github.ref_name }}) by ${{ github.actor }} is waiting for approval — tap to review." \
+          "$NTFY_URL/$NTFY_TOPIC" || true
+
   release:
+    needs: [notify-mobile-deploy]
     runs-on: ubuntu-latest
     environment: production
     defaults:


### PR DESCRIPTION
## Summary

- Adds a `notify-staging-deploy` job to `ci-cd.yml` that fires a high-priority ntfy push notification after tests pass, before the staging deploy environment gate
- Adds a `notify-production-deploy` job to `ci-cd.yml` that fires an urgent-priority ntfy push notification before the production deploy environment gate
- Adds a `notify-mobile-deploy` job to `mobile-release.yml` that fires before the EAS build/submit job
- Each notification includes the triggering commit/tag, actor, and a tappable link directly to the Actions run for one-tap approval


## Test Plan
- [ ] Add `NTFY_URL` and `NTFY_TOPIC` secrets to repo
- [ ] Push to master → verify staging notification arrives before deploy gate
- [ ] Push a `v*` tag → verify production notification arrives before deploy gate
- [ ] Push a `mobile-v*` tag → verify mobile notification arrives before EAS build starts