### PR TITLE
fix(frontend): prevent stale HTML being served after deploy

### DIFF
--- a/apps/frontend/next.config.ts
+++ b/apps/frontend/next.config.ts
@@ -12,6 +12,19 @@ const nextConfig: NextConfig = {
       },
     ];
   },
+  async headers() {
+    // Prevent shared caches (Caddy/CDN) from serving a stale HTML document after a
+    // deploy. Next.js defaults prerendered pages to `s-maxage=31536000`, so an old
+    // document keeps pointing at chunk hashes the new build no longer ships, which
+    // breaks the page until the cache expires. Hashed assets under /_next/static stay
+    // immutable; only the HTML documents must always revalidate against the origin.
+    return [
+      {
+        source: '/((?!_next/static|_next/image).*)',
+        headers: [{ key: 'Cache-Control', value: 'no-cache, must-revalidate' }],
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Problem

After deploying, the home page can render without its menu option tiles (only the title + "Tonight" strip show). The source, the production build, and the Docker artifact all render correctly — the issue is **HTTP caching**.

The live document at `whiskey.mjelde.us` is served with:

```
cache-control: s-maxage=31536000
```

This is Next.js's default for fully-prerendered App Router pages. A shared cache (Caddy/CDN) can therefore keep serving a **stale HTML document for up to a year**. After a new deploy, that old document still references `/_next/static` chunk hashes the new build no longer ships, so CSS/JS for parts of the page fail to load and the page renders broken until the cache happens to expire (or the user hard-refreshes).

## Fix

Override `Cache-Control` to `no-cache, must-revalidate` for HTML **document** routes only. Hashed assets under `/_next/static` (and `/_next/image`) stay `immutable`, so this costs one cheap ETag revalidation per navigation and nothing else.

## Verification (local prod build)

| Resource | Before | After |
|---|---|---|
| `/` (document) | `s-maxage=31536000` | `no-cache, must-revalidate` |
| `/data-view` (document) | `s-maxage=31536000` | `no-cache, must-revalidate` |
| `/_next/static/...css` | `public, max-age=31536000, immutable` | `public, max-age=31536000, immutable` (unchanged) |

Lint, 137 unit tests, and `next build` all pass.