### PR TITLE
feat(mobile): ship iOS to TestFlight alongside Android Play releases

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -6,10 +6,16 @@ name: Mobile Release
 # CI never handles it.
 #
 # Triggers:
-#   - push a tag `mobile-v*`  -> production AAB, auto-submitted to the Google
-#                                Play *internal testing* track
-#   - manual (Actions tab)    -> choose `preview` (shareable internal APK link)
-#                                or `production` (AAB, optionally submitted)
+#   - push a tag `mobile-v*`  -> production AAB auto-submitted to the Google
+#                                Play *internal testing* track, AND production
+#                                IPA auto-submitted to TestFlight
+#   - manual (Actions tab)    -> choose platform(s) and `preview` (shareable
+#                                internal APK link, Android only) or
+#                                `production` (optionally submitted)
+#
+# iOS submission uses the App Store Connect API key stored in EAS credentials
+# (set up during the first interactive `eas submit -p ios`) — no .p8 file or
+# Apple secrets are needed in CI, only EXPO_TOKEN.
 #
 # Decoupled from the backend `v*` tags used by ci-cd.yml.
 
@@ -18,13 +24,18 @@ on:
     tags: [ 'mobile-v*' ]
   workflow_dispatch:
     inputs:
+      platform:
+        description: 'Platform(s) to build'
+        type: choice
+        options: [ android, ios, all ]
+        default: android
       profile:
-        description: 'EAS build profile'
+        description: 'EAS build profile (preview is Android-only)'
         type: choice
         options: [ preview, production ]
         default: preview
       submit:
-        description: 'Submit production build to Play internal track'
+        description: 'Submit production build to Play internal / TestFlight'
         type: boolean
         default: false
 
@@ -33,7 +44,41 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  release:
+  notify-mobile-deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Notify mobile deploy pending
+      env:
+        NTFY_URL: ${{ secrets.NTFY_URL }}
+        NTFY_TOPIC: ${{ secrets.NTFY_TOPIC }}
+        NTFY_TOKEN: ${{ secrets.NTFY_TOKEN }}
+        NTFY_AUTH_USER: ${{ secrets.NTFY_AUTH_USER }}
+        NTFY_AUTH_PASS: ${{ secrets.NTFY_AUTH_PASS }}
+      run: |
+        if [ -z "$NTFY_URL" ] || [ -z "$NTFY_TOPIC" ]; then
+          echo "NTFY not configured, skipping notification"
+          exit 0
+        fi
+        PROFILE="${{ inputs.profile || 'production' }}"
+        RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        AUTH_ARGS=()
+        if [ -n "$NTFY_TOKEN" ]; then
+          AUTH_ARGS+=(-H "Authorization: Bearer $NTFY_TOKEN")
+        elif [ -n "$NTFY_AUTH_USER" ] && [ -n "$NTFY_AUTH_PASS" ]; then
+          AUTH_ARGS+=(-u "$NTFY_AUTH_USER:$NTFY_AUTH_PASS")
+        fi
+        curl -sf \
+          "${AUTH_ARGS[@]}" \
+          -H "Title: Mobile deploy needs approval" \
+          -H "Priority: high" \
+          -H "Tags: iphone,rocket" \
+          -H "Click: $RUN_URL" \
+          -d "Mobile $PROFILE build (${{ github.ref_name }}) by ${{ github.actor }} is waiting for approval — tap to review." \
+          "$NTFY_URL/$NTFY_TOPIC" || true
+
+  release-android:
+    needs: [notify-mobile-deploy]
+    if: github.event_name == 'push' || inputs.platform == 'android' || inputs.platform == 'all'
     runs-on: ubuntu-latest
     environment: production
     defaults:
@@ -101,3 +146,55 @@ jobs:
       - name: Remove service-account key
         if: always()
         run: rm -f google-service-account.json
+
+  release-ios:
+    needs: [notify-mobile-deploy]
+    # iOS has no preview path: internal (ad-hoc) distribution requires
+    # registered device UDIDs, so only the production profile is built here.
+    if: github.event_name == 'push' || ((inputs.platform == 'ios' || inputs.platform == 'all') && inputs.profile == 'production')
+    runs-on: ubuntu-latest
+    environment: production
+    defaults:
+      run:
+        working-directory: apps/mobile
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Resolve submit flag
+        id: cfg
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "push" ] || [ "${{ inputs.submit }}" = "true" ]; then
+            echo "submit=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "submit=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: apps/mobile/package-lock.json
+
+      - name: Set up EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type-check
+        run: npx tsc --noEmit
+
+      - name: Build (and auto-submit to TestFlight)
+        run: |
+          if [ "${{ steps.cfg.outputs.submit }}" = "true" ]; then
+            eas build --platform ios --profile production --non-interactive --auto-submit
+          else
+            eas build --platform ios --profile production --non-interactive --wait
+          fi

--- a/apps/mobile/DISTRIBUTION.md
+++ b/apps/mobile/DISTRIBUTION.md
@@ -1,9 +1,10 @@
-# Distributing the mobile app (Android — invite-only)
+# Distributing the mobile app (Android + iOS — invite-only)
 
-The app is shipped to a private group via the **Google Play internal testing**
-track: an email allowlist (≤100 testers). It is never publicly listed or
-searchable. Builds run on **EAS** (Expo's cloud) — no Android SDK or signing
-keystore is needed locally or in CI; EAS creates and stores the keystore once.
+The app is shipped to private groups on both platforms: **Google Play internal
+testing** (Android) and **Apple TestFlight internal testing** (iOS). Neither
+build is publicly listed or searchable; each track holds up to 100 testers.
+Builds run on **EAS** (Expo's cloud) — no local Android SDK, signing keystore,
+or Xcode is needed; EAS manages credentials for both platforms.
 
 > **NixOS / tooling:** there is no global `eas` command (don't `npm i -g`).
 > Always invoke it as `npx eas-cli@latest <args>`. `build:configure` is
@@ -50,30 +51,71 @@ change the server in-app under Settings (the stored value always wins).
    - `GOOGLE_SERVICE_ACCOUNT_JSON` — the full contents of the service-account
      JSON from step 4 (only needed for the auto-submit path).
 
+## iOS one-time setup
+
+Most of this is already done (Apple Developer Program enrolled, first production
+build completed via EAS, first submit to App Store Connect done — version 1.0.0
+build 1, bundle ID `com.whiskeytasting.app` is processing into TestFlight, and
+`submit.production.ios.ascAppId` is set in `eas.json` to `6779395691`, the
+numeric Apple ID from App Store Connect → App Information).
+
+**What remains before CI iOS submits work non-interactively:**
+
+1. **Verify the stored App Store Connect API key** — EAS stores the ASC API key
+   that was set up during the first interactive `eas submit -p ios`. Confirm it
+   is still present:
+   ```
+   npx eas-cli@latest credentials -p ios
+   ```
+   Look for the **App Store Connect API Key** section. If it is missing, re-run
+   `npx eas-cli@latest submit -p ios` interactively once to re-authorize.
+2. **Add TestFlight internal testers** — in App Store Connect → TestFlight →
+   Internal Testing, invite testers by Apple ID (up to 100). No Apple review is
+   required for internal testing; builds are available immediately after
+   processing and expire after 90 days.
+
+**No new GitHub secrets are needed.** iOS CI submission uses the ASC API key
+stored in EAS credentials, authenticated via the existing `EXPO_TOKEN` secret.
+There is no `.p8` file or Apple-specific secret in the repo or in GitHub.
+
 ## Routine releases
 
 **Automated (recommended).** The `Mobile Release` GitHub workflow
 (`.github/workflows/mobile-release.yml`):
 
-- **Production + auto-submit to Play internal:** push a tag —
+- **Production + auto-submit to both stores:** push a tag —
   ```
   git tag mobile-v1.0.1 && git push origin mobile-v1.0.1
   ```
-  Builds the AAB on EAS and submits it to the internal testing track.
-  versionCode is auto-incremented by EAS (`appVersionSource: remote`).
+  Two jobs run in parallel: `release-android` builds the AAB and submits it to
+  Play internal testing; `release-ios` builds the IPA and submits it to
+  TestFlight. versionCode/buildNumber are auto-incremented by EAS
+  (`appVersionSource: remote`).
 - **Manual run** (Actions tab → *Mobile Release* → *Run workflow*):
-  - `preview` → an internal-distribution **APK** with a shareable EAS link
-    (good for a quick one-off without touching Play).
-  - `production` + *submit* checkbox → AAB to Play internal.
+  - `platform` — choose `android`, `ios`, or `all` (default `android`).
+  - `profile`:
+    - `preview` → Android only: an internal-distribution **APK** with a
+      shareable EAS link (good for a quick one-off without touching Play).
+      There is no iOS preview path — ad-hoc iOS distribution requires
+      registered device UDIDs, so iOS is production-only.
+    - `production` → builds the store-ready binary for the selected platform(s).
+  - `submit` checkbox → when checked, submits to Play internal (Android) and/or
+    TestFlight (iOS) after the build completes. Only applies when
+    `profile=production`.
 
 Bump the user-facing version in `app.json` (`expo.version`) when meaningful;
-`versionCode` is managed remotely by EAS and need not be touched.
+`versionCode`/`buildNumber` is managed remotely by EAS and need not be touched.
 
 **Local equivalents** (from `apps/mobile/`, after one-time setup):
 
 ```
-npx eas-cli@latest build  -p android --profile preview                 # shareable APK link
-npx eas-cli@latest build  -p android --profile production --auto-submit # AAB → Play internal
+# Android
+npx eas-cli@latest build  -p android --profile preview                  # shareable APK link
+npx eas-cli@latest build  -p android --profile production --auto-submit  # AAB → Play internal
+
+# iOS
+npx eas-cli@latest build  -p ios --profile production --auto-submit      # IPA → TestFlight
+npx eas-cli@latest submit -p ios --latest                                 # submit existing build
 ```
 
 ## Notes
@@ -82,3 +124,9 @@ npx eas-cli@latest build  -p android --profile production --auto-submit # AAB �
 - The local NixOS `./gradlew assembleRelease` flow (debug-signed APK) still
   works for ad-hoc sideloading but is unrelated to Play distribution — Play
   builds must come through EAS so they use the managed upload key.
+- iOS has no preview/ad-hoc distribution path. To test on a specific device
+  before a TestFlight release, register the device UDID in your Apple Developer
+  account and use an ad-hoc profile — but for this project's cadence, TestFlight
+  internal testing is the intended path.
+- TestFlight builds expire after 90 days. Testers must update before expiry or
+  re-download from TestFlight.

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -14,7 +14,10 @@
     },
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.whiskeytasting.app"
+      "bundleIdentifier": "com.whiskeytasting.app",
+      "infoPlist": {
+        "ITSAppUsesNonExemptEncryption": false
+      }
     },
     "android": {
       "adaptiveIcon": {

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -33,6 +33,9 @@
         "track": "internal",
         "releaseStatus": "completed",
         "serviceAccountKeyPath": "./google-service-account.json"
+      },
+      "ios": {
+        "ascAppId": "6779395691"
       }
     }
   }


### PR DESCRIPTION
## Summary

- `mobile-v*` tags now build and auto-submit **both** platforms on EAS: Android AAB → Play internal testing, iOS IPA → TestFlight.
- New `release-ios` job in `mobile-release.yml`; existing job renamed `release-android`. Manual dispatch gains a `platform` input (android / ios / all).
- iOS submits authenticate via the App Store Connect API key stored in EAS credentials — no new GitHub secrets (only existing `EXPO_TOKEN`).
- `eas.json`: iOS submit profile with `ascAppId`. `app.json`: `ITSAppUsesNonExemptEncryption: false` (HTTPS-only app, skips the export-compliance prompt per upload).
- iOS has no preview path: ad-hoc distribution would require registered device UDIDs, so the iOS job only builds the production profile.
- `DISTRIBUTION.md` updated with the iOS one-time setup and routine-release runbook.

## Test plan

- YAML validated locally.
- First iOS production build (1.0.0 build 1) already built on EAS and submitted to App Store Connect manually — processing into TestFlight.
- After merge: push `mobile-v1.0.3` and verify both CI jobs (Play internal + TestFlight submit) succeed.